### PR TITLE
Add marketing landing page with hero variations

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -1,0 +1,13 @@
+// Basic scroll reveal
+window.addEventListener('DOMContentLoaded', () => {
+  const observer = new IntersectionObserver((entries) => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        entry.target.classList.add('reveal');
+        observer.unobserve(entry.target);
+      }
+    });
+  }, { threshold: 0.1 });
+
+  document.querySelectorAll('.reveal-on-scroll').forEach(el => observer.observe(el));
+});

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,0 +1,82 @@
+:root {
+  --brand-gradient: linear-gradient(135deg, #667eea 0%, #764ba2 25%, #f093fb 50%, #f5576c 75%, #fda085 100%);
+  --glass-bg: rgba(255, 255, 255, 0.05);
+  --glass-border: rgba(255, 255, 255, 0.1);
+  --glass-hover: rgba(255, 255, 255, 0.08);
+}
+
+body {
+  font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+}
+
+.gradient-text {
+  background: var(--brand-gradient);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  animation: gradient-shift 8s ease infinite;
+  background-size: 200% 200%;
+}
+
+@keyframes gradient-shift {
+  0% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
+}
+
+.hero-bg {
+  position: relative;
+  background: radial-gradient(circle at 20% 20%, rgba(255,255,255,0.1), transparent 40%),
+              radial-gradient(circle at 80% 80%, rgba(255,255,255,0.1), transparent 40%),
+              var(--brand-gradient);
+  background-size: cover;
+}
+
+.hero-bg::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: var(--brand-gradient);
+  opacity: 0.2;
+  mix-blend-mode: overlay;
+  animation: float 12s ease-in-out infinite;
+}
+
+@keyframes float {
+  0%, 100% { transform: translateY(-5%); }
+  50% { transform: translateY(5%); }
+}
+
+.glass-card {
+  background: var(--glass-bg);
+  backdrop-filter: blur(10px);
+  border: 1px solid var(--glass-border);
+  border-radius: 1rem;
+  transition: all 0.3s ease;
+}
+.glass-card:hover {
+  background: var(--glass-hover);
+  transform: translateY(-4px);
+}
+
+.cta-button {
+  display: inline-block;
+  padding: 0.75rem 1.5rem;
+  background: var(--brand-gradient);
+  border-radius: 9999px;
+  font-weight: 700;
+  transition: transform 0.3s ease;
+}
+.cta-button:hover {
+  transform: scale(1.05);
+}
+
+.reveal-on-scroll {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.5s ease, transform 0.5s ease;
+}
+.reveal-on-scroll.reveal {
+  opacity: 1;
+  transform: translateY(0);
+}

--- a/index.php
+++ b/index.php
@@ -1,0 +1,11 @@
+<?php
+include __DIR__ . '/partials/head.php';
+
+include __DIR__ . '/partials/hero-1.php';
+include __DIR__ . '/partials/hero-2.php';
+include __DIR__ . '/partials/hero-3.php';
+include __DIR__ . '/partials/problem.php';
+include __DIR__ . '/partials/concept.php';
+include __DIR__ . '/partials/final-cta.php';
+include __DIR__ . '/partials/footer.php';
+?>

--- a/partials/concept.php
+++ b/partials/concept.php
@@ -1,0 +1,22 @@
+<section class="py-20 bg-gray-900">
+  <div class="container mx-auto px-6 max-w-5xl text-center reveal-on-scroll">
+    <h2 class="text-4xl md:text-5xl font-bold gradient-text mb-12">Why it's different</h2>
+    <div class="grid md:grid-cols-3 gap-8">
+      <div class="glass-card p-6">
+        <div class="text-4xl mb-4">🍛</div>
+        <h3 class="font-semibold text-xl mb-2">Feeds Developers</h3>
+        <p class="text-gray-300">100% of profits nourish local talent.</p>
+      </div>
+      <div class="glass-card p-6">
+        <div class="text-4xl mb-4">🛠️</div>
+        <h3 class="font-semibold text-xl mb-2">Builds Tools</h3>
+        <p class="text-gray-300">Your support funds community tools.</p>
+      </div>
+      <div class="glass-card p-6">
+        <div class="text-4xl mb-4">🤝</div>
+        <h3 class="font-semibold text-xl mb-2">Grows Community</h3>
+        <p class="text-gray-300">Wearing the shirt spreads the word.</p>
+      </div>
+    </div>
+  </div>
+</section>

--- a/partials/final-cta.php
+++ b/partials/final-cta.php
@@ -1,0 +1,7 @@
+<section class="py-20 bg-gradient-to-r from-purple-900 to-pink-900 text-center">
+  <div class="container mx-auto px-6 max-w-3xl reveal-on-scroll">
+    <h2 class="text-4xl md:text-5xl font-bold mb-6">Buy the shirt. Feed Carl.</h2>
+    <p class="text-xl text-gray-200 mb-8">Every purchase fuels Filipino web creators.</p>
+    <a href="https://freelancesolutions.myshopify.com/" class="cta-button text-white">Shop Now</a>
+  </div>
+</section>

--- a/partials/footer.php
+++ b/partials/footer.php
@@ -1,0 +1,5 @@
+<footer class="py-12 bg-gray-900 border-t border-gray-800 text-center">
+  <p class="text-gray-400 text-sm">&copy; <?php echo date('Y'); ?> WordPress Jobs Philippines</p>
+</footer>
+</body>
+</html>

--- a/partials/head.php
+++ b/partials/head.php
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>WordPress Jobs Philippines</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800;900&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/style.css" />
+  <script defer src="assets/main.js"></script>
+</head>
+<body class="bg-gray-900 text-white overflow-x-hidden">

--- a/partials/hero-1.php
+++ b/partials/hero-1.php
@@ -1,0 +1,13 @@
+<section class="hero-bg min-h-[100svh] flex items-center justify-center relative text-center">
+  <div class="container mx-auto px-6 max-w-3xl">
+    <h1 class="text-5xl md:text-7xl font-extrabold gradient-text mb-6">Buy a T-shirt, Feed Carl</h1>
+    <p class="text-xl md:text-2xl text-gray-300 mb-8">Do you want to say you helped grow the Philippine Web Dev community instead of just talking about change?</p>
+    <a href="https://freelancesolutions.myshopify.com/" class="cta-button text-white">We need your help!</a>
+    <div class="mt-10 grid grid-cols-1 md:grid-cols-3 gap-4">
+      <div class="glass-card p-4 text-gray-300 text-sm">100% profit feeds devs</div>
+      <div class="glass-card p-4 text-gray-300 text-sm">Limited edition swag</div>
+      <div class="glass-card p-4 text-gray-300 text-sm">#feedcarl</div>
+    </div>
+  </div>
+  <div class="absolute bottom-6 left-1/2 -translate-x-1/2 text-gray-400 animate-bounce">⬇️</div>
+</section>

--- a/partials/hero-2.php
+++ b/partials/hero-2.php
@@ -1,0 +1,13 @@
+<section class="hero-bg min-h-[100svh] flex items-center justify-center relative text-center">
+  <div class="container mx-auto px-6 max-w-3xl">
+    <h1 class="text-5xl md:text-7xl font-extrabold gradient-text mb-6">Wear the Mindset</h1>
+    <p class="text-xl md:text-2xl text-gray-300 mb-8">Every shirt powers better tools and a thriving community of indie builders.</p>
+    <a href="https://freelancesolutions.myshopify.com/" class="cta-button text-white">Get the Shirt</a>
+    <div class="mt-10 grid grid-cols-1 md:grid-cols-3 gap-4">
+      <div class="glass-card p-4 text-gray-300 text-sm">Fuel Filipino devs</div>
+      <div class="glass-card p-4 text-gray-300 text-sm">Show your support</div>
+      <div class="glass-card p-4 text-gray-300 text-sm">Join the movement</div>
+    </div>
+  </div>
+  <div class="absolute bottom-6 left-1/2 -translate-x-1/2 text-gray-400 animate-bounce">⬇️</div>
+</section>

--- a/partials/hero-3.php
+++ b/partials/hero-3.php
@@ -1,0 +1,13 @@
+<section class="hero-bg min-h-[100svh] flex items-center justify-center relative text-center">
+  <div class="container mx-auto px-6 max-w-3xl">
+    <h1 class="text-5xl md:text-7xl font-extrabold gradient-text mb-6">Build the Future</h1>
+    <p class="text-xl md:text-2xl text-gray-300 mb-8">100% of profits go directly to hungry web devs like Carl who’s tired of Skyflakes.</p>
+    <a href="https://freelancesolutions.myshopify.com/" class="cta-button text-white">Feed the Builders</a>
+    <div class="mt-10 grid grid-cols-1 md:grid-cols-3 gap-4">
+      <div class="glass-card p-4 text-gray-300 text-sm">Support local talent</div>
+      <div class="glass-card p-4 text-gray-300 text-sm">Create future tools</div>
+      <div class="glass-card p-4 text-gray-300 text-sm">#wordpressjobsphilippines</div>
+    </div>
+  </div>
+  <div class="absolute bottom-6 left-1/2 -translate-x-1/2 text-gray-400 animate-bounce">⬇️</div>
+</section>

--- a/partials/problem.php
+++ b/partials/problem.php
@@ -1,0 +1,12 @@
+<section class="py-20 bg-gray-800">
+  <div class="container mx-auto px-6 max-w-4xl reveal-on-scroll">
+    <h2 class="text-4xl md:text-5xl font-bold mb-6 gradient-text text-center">Why this matters</h2>
+    <div class="grid md:grid-cols-2 gap-8 items-center">
+      <div>
+        <p class="text-gray-300 text-lg mb-4">Every shirt you wear helps us take one step closer to building a stronger community, better tools, and a future where independent creators thrive.</p>
+        <p class="text-gray-300 text-lg">Help us feed developers like Carl who’s tired of Skyflakes.</p>
+      </div>
+      <img src="https://source.unsplash.com/featured/?community,philippines" alt="Community" class="rounded-2xl shadow-lg" />
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
## Summary
- build Tailwind landing page for WordPress Jobs PH campaign
- include three hero copy variations and glass-card sections
- add brand gradient styles and scroll reveal script

## Testing
- `php -l index.php`
- `php -l partials/head.php`
- `php -l partials/footer.php`
- `php -l partials/hero-1.php`
- `php -l partials/hero-2.php`
- `php -l partials/hero-3.php`
- `php -l partials/problem.php`
- `php -l partials/concept.php`
- `php -l partials/final-cta.php`


------
https://chatgpt.com/codex/tasks/task_e_68b1093cd7908330b7ded045eb4564f5