### PR TITLE
Add storytelling landing page for WP Jobs PH

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -1,0 +1,12 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const observer = new IntersectionObserver(entries => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        entry.target.classList.add('visible');
+        observer.unobserve(entry.target);
+      }
+    });
+  }, { threshold: 0.1 });
+
+  document.querySelectorAll('.reveal').forEach(el => observer.observe(el));
+});

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,0 +1,140 @@
+:root {
+  --brand-gradient: linear-gradient(135deg, #667eea 0%, #764ba2 25%, #f093fb 50%, #f5576c 75%, #fda085 100%);
+  --glass-bg: rgba(255,255,255,0.05);
+  --glass-border: rgba(255,255,255,0.1);
+  --glass-hover: rgba(255,255,255,0.15);
+}
+
+body {
+  font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  background-color: #111827;
+  color: #ffffff;
+  margin: 0;
+  overflow-x: hidden;
+}
+
+.container {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+section {
+  padding: 5rem 0;
+}
+
+.hero {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  background-color: #1f2937;
+  position: relative;
+}
+
+.gradient-text {
+  background: var(--brand-gradient);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  color: transparent;
+  background-size: 400% 400%;
+  animation: gradient-shift 8s ease infinite;
+}
+
+.cta-button {
+  padding: 0.75rem 2rem;
+  border: none;
+  border-radius: 9999px;
+  background: var(--brand-gradient);
+  color: #fff;
+  font-size: 1.125rem;
+  cursor: pointer;
+  transition: transform .3s;
+}
+
+.cta-button:hover {
+  transform: scale(1.05);
+}
+
+.metrics {
+  margin-top: 3rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px,1fr));
+  gap: 1.5rem;
+  width: 100%;
+  max-width: 600px;
+}
+
+.glass-card {
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  border-radius: 1rem;
+  padding: 2rem;
+  backdrop-filter: blur(10px);
+  transition: background .3s;
+}
+
+.glass-card:hover {
+  background: var(--glass-hover);
+}
+
+.bg-alt {
+  background-color: #1f2937;
+}
+
+.section-title {
+  font-size: 2.25rem;
+  margin-bottom: 1.5rem;
+  text-align: center;
+}
+
+.section-text {
+  font-size: 1.125rem;
+  color: #d1d5db;
+  max-width: 700px;
+  margin: 0 auto;
+  text-align: center;
+}
+
+.flex-center {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  gap: 1.5rem;
+  margin-top: 2rem;
+}
+
+.img-card {
+  width: 16rem;
+  border-radius: 1rem;
+  object-fit: cover;
+}
+
+.reveal {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity .6s ease, transform .6s ease;
+}
+
+.reveal.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+footer {
+  background-color: #111827;
+  padding: 3rem 0;
+  text-align: center;
+  color: #9ca3af;
+  font-size: 0.875rem;
+}
+
+@keyframes gradient-shift {
+  0% {background-position:0% 50%;}
+  50% {background-position:100% 50%;}
+  100% {background-position:0% 50%;}
+}

--- a/index.php
+++ b/index.php
@@ -1,0 +1,10 @@
+<?php
+include __DIR__ . '/partials/header.php';
+
+include __DIR__ . '/sections/hero.php';
+include __DIR__ . '/sections/problem.php';
+include __DIR__ . '/sections/solution.php';
+include __DIR__ . '/sections/impact.php';
+include __DIR__ . '/sections/cta.php';
+
+include __DIR__ . '/partials/footer.php';

--- a/partials/footer.php
+++ b/partials/footer.php
@@ -1,0 +1,5 @@
+<footer>
+  <p>&copy; <?php echo date('Y'); ?> WordPress Jobs Philippines</p>
+</footer>
+</body>
+</html>

--- a/partials/header.php
+++ b/partials/header.php
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>WordPress Jobs PH – Feed Carl</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/style.css" />
+  <script defer src="assets/script.js"></script>
+</head>
+<body>

--- a/sections/cta.php
+++ b/sections/cta.php
@@ -1,0 +1,7 @@
+<section class="reveal">
+  <div class="container">
+    <h2 class="section-title gradient-text">Join the Movement</h2>
+    <p class="section-text" style="margin-bottom:2rem;">Wear the mindset. Feed the builders. Build the future.</p>
+    <button class="cta-button" onclick="window.location.href='https://freelancesolutions.myshopify.com/'">Buy the Shirt</button>
+  </div>
+</section>

--- a/sections/hero.php
+++ b/sections/hero.php
@@ -1,0 +1,21 @@
+<section class="hero">
+  <div class="container">
+    <h1 class="gradient-text" style="font-size:3.5rem;font-weight:800;">Buy a T-shirt, Feed Carl</h1>
+    <p class="section-text" style="margin-top:1rem;">Every shirt fuels the Philippine WordPress community and keeps builders like Carl going.</p>
+    <button class="cta-button" style="margin-top:2rem;" onclick="window.location.href='https://freelancesolutions.myshopify.com/'">Get the Shirt</button>
+    <div class="metrics reveal">
+      <div class="glass-card">
+        <p style="font-size:2rem;font-weight:700;">100%</p>
+        <p class="section-text" style="margin-top:0.5rem;">Profit to devs</p>
+      </div>
+      <div class="glass-card">
+        <p style="font-size:2rem;font-weight:700;">1</p>
+        <p class="section-text" style="margin-top:0.5rem;">Hungry Carl</p>
+      </div>
+      <div class="glass-card">
+        <p style="font-size:2rem;font-weight:700;">∞</p>
+        <p class="section-text" style="margin-top:0.5rem;">Community impact</p>
+      </div>
+    </div>
+  </div>
+</section>

--- a/sections/impact.php
+++ b/sections/impact.php
@@ -1,0 +1,6 @@
+<section class="bg-alt reveal">
+  <div class="container">
+    <h2 class="section-title gradient-text">Your Impact</h2>
+    <p class="section-text">Each shirt funds better tools, meetups, and meals. You're not just buying swag—you're investing in a community of builders.</p>
+  </div>
+</section>

--- a/sections/problem.php
+++ b/sections/problem.php
@@ -1,0 +1,6 @@
+<section class="bg-alt reveal">
+  <div class="container">
+    <h2 class="section-title gradient-text">Why It Matters</h2>
+    <p class="section-text">Talented web developers across the Philippines struggle to access resources, mentorship, and proper meals. Carl survives on Skyflakes while building the web. We can do better.</p>
+  </div>
+</section>

--- a/sections/solution.php
+++ b/sections/solution.php
@@ -1,0 +1,10 @@
+<section class="reveal">
+  <div class="container">
+    <h2 class="section-title gradient-text">The Idea</h2>
+    <p class="section-text">We created limited edition shirts for WordPress Jobs Philippines. Every purchase feeds a developer and funds community tools.</p>
+    <div class="flex-center">
+      <img src="images/shirt_WordPress Developer T-Shirt - Gift for Freelancers Tech Lovers Casual Wear Programmer Shirt Funny Coding Tee.jpg" alt="WordPress Developer shirt" class="img-card glass-card" />
+      <img src="images/shirt_Faded Shirt - Never Stop Trying - Inspirational Tee.jpg" alt="Never Stop Trying shirt" class="img-card glass-card" />
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
## Summary
- build modular PHP landing page with dark gradient hero and clear storytelling
- separate CSS and JS assets for brand gradient, glass cards, and scroll reveal motion
- include narrative sections guiding visitors from problem to action

## Testing
- `php -l index.php`
- `php -l partials/header.php partials/footer.php sections/hero.php sections/problem.php sections/solution.php sections/impact.php sections/cta.php`


------
https://chatgpt.com/codex/tasks/task_e_68b11c4d6b388330a6766e57d12eb7b8