### PR TITLE
Add story-driven landing page

### DIFF
--- a/assets/brand.css
+++ b/assets/brand.css
@@ -1,0 +1,73 @@
+:root {
+  --brand-gradient: linear-gradient(135deg, #667eea 0%, #764ba2 25%, #f093fb 50%, #f5576c 75%, #fda085 100%);
+  --glass-bg: rgba(255,255,255,0.05);
+  --glass-border: rgba(255,255,255,0.1);
+  --glass-hover: rgba(255,255,255,0.08);
+}
+
+* {
+  font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+}
+
+.gradient-text {
+  background: var(--brand-gradient);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.glass-card {
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(10px);
+  border-radius: 1rem;
+  transition: all .3s;
+}
+.glass-card:hover {
+  background: var(--glass-hover);
+  transform: translateY(-4px);
+}
+
+.cta-button {
+  background: var(--brand-gradient);
+  padding: 0.75rem 1.5rem;
+  border-radius: 9999px;
+  font-weight: 600;
+  display: inline-block;
+  transition: all .3s;
+}
+.cta-button:hover {
+  filter: brightness(1.1);
+  transform: scale(1.05);
+}
+
+.hero-bg {
+  background: var(--brand-gradient);
+  position: relative;
+  overflow: hidden;
+}
+.hero-bg::before {
+  content: '';
+  position: absolute;
+  top: -50%;
+  left: -50%;
+  width: 200%;
+  height: 200%;
+  background: radial-gradient(circle, rgba(255,255,255,0.15), transparent 70%);
+  animation: float 20s linear infinite;
+}
+
+@keyframes float {
+  from { transform: translate(0,0); }
+  to { transform: translate(25%,25%); }
+}
+
+.reveal {
+  opacity: 0;
+  transform: translateY(20px);
+}
+.reveal.visible {
+  opacity: 1;
+  transform: none;
+  transition: opacity .6s ease, transform .6s ease;
+}

--- a/assets/script.js
+++ b/assets/script.js
@@ -1,0 +1,12 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const observer = new IntersectionObserver((entries) => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        entry.target.classList.add('visible');
+        observer.unobserve(entry.target);
+      }
+    });
+  }, {threshold: 0.1});
+
+  document.querySelectorAll('.reveal').forEach(el => observer.observe(el));
+});

--- a/config.php
+++ b/config.php
@@ -1,0 +1,72 @@
+<?php
+return [
+  'brand' => [
+    'name' => 'WordPress Jobs Philippines'
+  ],
+  'hero' => [
+    'title' => 'Feed the Future of Web Dev',
+    'lede' => 'Buy the shirt. Fuel Filipino WordPress builders.',
+    'primary_cta' => ['label' => 'Buy the Shirt', 'href' => 'https://freelancesolutions.myshopify.com/'],
+    'metrics' => [
+      ['value' => '100%', 'label' => 'Profit to Devs'],
+      ['value' => '1', 'label' => 'Hungry Dev Fed'],
+      ['value' => '∞', 'label' => 'Community Impact'],
+    ],
+  ],
+  'sections' => [
+    [
+      'id' => 'problem',
+      'bg' => 'bg-gray-800',
+      'title' => 'When Builders Go Hungry',
+      'content_html' => '<p>Carl is a talented WordPress dev in Pampanga, surviving on Skyflakes while building the future.</p><p>Too many local devs have the skills but not the support.</p><img src="images/Philippines_developer.jpg" alt="Philippines developer" class="w-full rounded-lg mt-6" />',
+    ],
+    [
+      'id' => 'idea',
+      'bg' => 'bg-gray-900',
+      'title' => 'A Shirt That Feeds',
+      'content_html' => '<p class="text-xl text-gray-300">Buy a T‑shirt, wear the mindset, and every peso of profit feeds our community devs.</p><img src="images/shirt_WordPress Developer T-Shirt - Gift for Freelancers Tech Lovers Casual Wear Programmer Shirt Funny Coding Tee.jpg" alt="WordPress developer shirt" class="w-full rounded-lg mt-6" />',
+    ],
+    [
+      'id' => 'how-it-works',
+      'bg' => 'bg-gray-800',
+      'title' => 'From Cotton to Code',
+      'content_html' => '<p class="mb-8">It\'s simple:</p>',
+      'cards' => [
+        ['icon' => '1️⃣', 'title' => 'Buy the shirt', 'copy' => 'Grab one from our store'],
+        ['icon' => '2️⃣', 'title' => 'Profits feed devs', 'copy' => '100% goes to builders'],
+        ['icon' => '3️⃣', 'title' => 'Community grows', 'copy' => 'Fuel projects & careers'],
+      ],
+    ],
+    [
+      'id' => 'proof',
+      'bg' => 'bg-gray-900',
+      'title' => 'Your Impact',
+      'content_html' => '<p class="text-xl text-gray-300">Every shirt you wear helps us build a stronger web dev community.</p>',
+      'cards' => [
+        ['image' => 'images/Philippines_busy_street_9x16.jpg', 'title' => 'Real People', 'copy' => 'Each shirt feeds a real dev like Carl'],
+        ['image' => 'https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=800&q=80', 'title' => 'Community', 'copy' => 'Funds events and tools for local devs'],
+        ['image' => 'images/code_html_code_on_screen_zoomed_16x9.jpg', 'title' => 'Open Source', 'copy' => 'Supports projects the whole world uses'],
+      ],
+    ],
+    [
+      'id' => 'merch',
+      'bg' => 'bg-gray-800',
+      'title' => 'Choose Your Style',
+      'cards' => [
+        ['image' => 'images/shirt_WordPress Developer T-Shirt - Gift for Freelancers Tech Lovers Casual Wear Programmer Shirt Funny Coding Tee.jpg', 'title' => 'WordPress Dev Tee', 'copy' => 'Classic black, feeds a dev'],
+        ['image' => 'images/shirt_Faded Shirt - Never Stop Trying - Inspirational Tee.jpg', 'title' => 'Never Stop Trying Tee', 'copy' => 'Wear your hustle'],
+        ['image' => 'images/hoodie_Street Style Unisex College Hoodie - Casual Wear Comfortable Sweatshirt Gift for Students  Streetwear Fashion.jpg', 'title' => 'College Hoodie', 'copy' => 'Cozy support for builders'],
+      ],
+    ],
+    [
+      'id' => 'cta',
+      'bg' => 'bg-gradient-to-r from-purple-900 to-pink-900',
+      'title' => 'Be Part of the Build',
+      'content_html' => '<p class="text-xl md:text-2xl mb-12 max-w-3xl mx-auto text-gray-200">100% of profits feed Filipino web devs. Join us.</p>',
+      'cta' => ['label' => 'Buy the Shirt', 'href' => 'https://freelancesolutions.myshopify.com/'],
+    ],
+  ],
+  'footer' => [
+    'copy' => 'WordPress Jobs Philippines — feeding code, one shirt at a time.'
+  ],
+];

--- a/index.php
+++ b/index.php
@@ -1,0 +1,12 @@
+<?php
+$config = require __DIR__ . '/config.php';
+require __DIR__ . '/lib/components.php';
+include __DIR__ . '/partials/head.php';
+
+render_hero($config['brand'], $config['hero']);
+
+foreach ($config['sections'] as $sec) {
+  render_section($sec);
+}
+
+include __DIR__ . '/partials/footer.php';

--- a/lib/components.php
+++ b/lib/components.php
@@ -1,0 +1,62 @@
+<?php
+function e($str){ return htmlspecialchars($str, ENT_QUOTES, 'UTF-8'); }
+
+function render_hero($brand, $hero){
+?>
+<section class="hero-bg min-h-[100svh] flex items-center justify-center text-center px-6">
+  <div class="max-w-3xl">
+    <h1 class="text-4xl md:text-6xl font-extrabold gradient-text mb-6"><?= $hero['title']; ?></h1>
+    <p class="text-xl md:text-2xl text-gray-200 mb-8"><?= $hero['lede']; ?></p>
+    <?php if(isset($hero['primary_cta'])): ?>
+      <a href="<?= e($hero['primary_cta']['href']); ?>" class="cta-button"><?= e($hero['primary_cta']['label']); ?></a>
+    <?php endif; ?>
+    <?php if(!empty($hero['metrics'])): ?>
+      <div class="mt-12 grid grid-cols-1 sm:grid-cols-3 gap-6">
+        <?php foreach($hero['metrics'] as $m): ?>
+          <div class="metric-card text-center">
+            <div class="text-2xl font-bold"><?= e($m['value']); ?></div>
+            <div class="text-gray-400"><?= e($m['label']); ?></div>
+          </div>
+        <?php endforeach; ?>
+      </div>
+    <?php endif; ?>
+  </div>
+</section>
+<?php
+}
+
+function render_section($sec){
+  $bg = $sec['bg'] ?? 'bg-gray-800';
+?>
+<section id="<?= e($sec['id']); ?>" class="<?= e($bg); ?> py-20">
+  <div class="container mx-auto px-6 max-w-4xl">
+    <?php if(isset($sec['title'])): ?>
+      <h2 class="text-3xl md:text-4xl font-bold mb-8 gradient-text"><?= $sec['title']; ?></h2>
+    <?php endif; ?>
+    <?php if(isset($sec['content_html'])): ?>
+      <div class="text-lg text-gray-300 space-y-6 reveal"><?= $sec['content_html']; ?></div>
+    <?php endif; ?>
+    <?php if(!empty($sec['cards'])): ?>
+      <div class="mt-12 grid gap-6 sm:grid-cols-2 md:grid-cols-3">
+        <?php foreach($sec['cards'] as $card): ?>
+          <div class="glass-card p-6 reveal">
+            <?php if(isset($card['image'])): ?>
+              <img src="<?= e($card['image']); ?>" alt="<?= e($card['title']); ?>" class="w-full h-40 object-cover rounded-lg mb-4" />
+            <?php elseif(isset($card['icon'])): ?>
+              <div class="text-3xl mb-2"><?= e($card['icon']); ?></div>
+            <?php endif; ?>
+            <h3 class="text-xl font-semibold mb-2"><?= e($card['title']); ?></h3>
+            <p class="text-gray-400 text-sm"><?= e($card['copy']); ?></p>
+          </div>
+        <?php endforeach; ?>
+      </div>
+    <?php endif; ?>
+    <?php if(isset($sec['cta'])): ?>
+      <div class="mt-12 text-center">
+        <a href="<?= e($sec['cta']['href']); ?>" class="cta-button"><?= e($sec['cta']['label']); ?></a>
+      </div>
+    <?php endif; ?>
+  </div>
+</section>
+<?php
+}

--- a/partials/footer.php
+++ b/partials/footer.php
@@ -1,0 +1,9 @@
+<?php $footer = $config['footer'] ?? []; ?>
+<footer class="py-12 bg-gray-900 border-t border-gray-800">
+  <div class="container mx-auto px-6 text-center">
+    <p class="text-2xl font-bold gradient-text mb-4"><?= htmlspecialchars($config['brand']['name'] ?? ''); ?></p>
+    <p class="text-gray-400"><?= htmlspecialchars($footer['copy'] ?? ''); ?></p>
+  </div>
+</footer>
+</body>
+</html>

--- a/partials/head.php
+++ b/partials/head.php
@@ -1,0 +1,13 @@
+<?php $brand = $config['brand'] ?? []; ?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title><?= htmlspecialchars($brand['name'] ?? ''); ?></title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/brand.css" />
+  <script defer src="assets/script.js"></script>
+</head>
+<body class="bg-gray-900 text-white overflow-x-hidden">


### PR DESCRIPTION
## Summary
- Build dark, glassy landing page structure in PHP with configurable sections
- Style hero, cards, and calls to action using gradient tokens and scroll reveals
- Populate copy and merch cards to support WordPress Jobs Philippines community

## Testing
- `php -l index.php`
- `php -l config.php lib/components.php partials/head.php partials/footer.php`


------
https://chatgpt.com/codex/tasks/task_e_68b11c4d6b388330a6766e57d12eb7b8